### PR TITLE
Add ocp-24871-datagrid testcase

### DIFF
--- a/e2e_mig_samples.yml
+++ b/e2e_mig_samples.yml
@@ -23,6 +23,8 @@
     - { role: ocp-26160-max-pvs, tags: ["ocp-26160-max-pvs", "ocp"] }
     - { role: ocp-24787-redis, tags: ["ocp-24787-redis", "ocp"] }
     - { role: ocp-24797-mongodb, tags: ["ocp-24797-mongodb", "ocp"] }
+    # This tests deploys the official datagrid service application in openshift. It doesnt exist before 3.11
+    - { role: ocp-24871-datagrid, tags: ["never" ,"ocp-24871-datagrid"] }
   vars_files:
     - "{{ playbook_dir }}/config/mig_controller.yml"
     - "{{ playbook_dir }}/config/defaults.yml"

--- a/roles/ocp-24871-datagrid/defaults/main.yml
+++ b/roles/ocp-24871-datagrid/defaults/main.yml
@@ -1,0 +1,21 @@
+namespace: ocp-24871-datagrid
+
+num_dg_instances: 1
+app_password: changeme
+app_user: test
+hotrod_client_sourcecode: "{{ role_path }}/files/hotrod_client_app_template.yml"
+cronjob_insert_sourcecode: "{{ role_path }}/files/cronjob_app_template.yml"
+cron_name: rest-insert
+rest_cache_name: "restcache"
+hotrod_cache_name: "hotrodcache"
+
+migration_sample_name: "{{ namespace }}"
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+#migration_sample_files: "{{ playbook_dir }}/mig-controller/docs/scenarios/{{ migration_sample_name }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: false

--- a/roles/ocp-24871-datagrid/files/cronjob_app_template.yml
+++ b/roles/ocp-24871-datagrid/files/cronjob_app_template.yml
@@ -1,0 +1,69 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  template: datagrid-cronjob
+message: |-
+  Creates a cronjob to insert data in a datagrid cache
+
+objects:
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    name: ${CRON_NAME}
+    labels:
+      application: ${CRON_NAME}
+  spec:
+    schedule: "*/1 * * * *"
+    jobTemplate:
+      spec:
+        template:
+          metadata:
+            labels:
+              application: ${CRON_NAME}
+          spec:
+            containers:
+            - name: ${CRON_NAME}
+              env:
+              - name: CURRENT_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              image: alpine
+              args:
+              - /bin/sh
+              - -c
+              -  wget -q -S -O -  https://${DATAGRID_USERNAME}:${DATAGRID_PASSWORD}@${DATAGRID_SERVICE}:8443/rest/${CACHE}/${HOSTNAME}  --no-check-certificate --post-data "${DATA}"
+            restartPolicy: OnFailure
+
+parameters:
+- description: Name of the cronjob deployed
+  displayName: Name
+  name: CRON_NAME
+  required: true
+  value: "insert"
+- description: Datagrid service that exposes the datagrid rest api.
+  displayName: Datagrid Service
+  name: DATAGRID_SERVICE
+  required: true
+  value: "datagrid-service"
+- description: Username used to authenticate in datagrid 
+  displayName: Datagrid Username
+  name: DATAGRID_USERNAME
+  required: true
+  value: "test"
+- description: Password used to authenticate in datagrid 
+  displayName: Datagrid Password
+  name: DATAGRID_PASSWORD
+  required: true
+  value: "changeme"
+- description: Name of the cache where the data will be inserted.
+  displayName: Cache Name
+  name: CACHE
+  required: true
+  value:  'default'
+- description: Username used to authenticate in datagrid 
+  displayName: Datagrid Username
+  name: DATA
+  required: true
+  value:  '{ \"namespace\":\"${CURRENT_NAMESPACE}\" }'
+

--- a/roles/ocp-24871-datagrid/files/hotrod_client_app_template.yml
+++ b/roles/ocp-24871-datagrid/files/hotrod_client_app_template.yml
@@ -1,0 +1,328 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  template: eap71-basic-s2i
+  xpaas: 1.4.17
+message: A new EAP 7 based application has been created in your project.
+metadata:
+  annotations:
+    description: An example EAP 7 application. For more information about using this
+      template, see https://github.com/jboss-openshift/application-templates.
+    iconClass: icon-eap
+    openshift.io/display-name: JBoss EAP 7.1 (no https)
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: eap,javaee,java,jboss
+    template.openshift.io/documentation-url: https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/
+    template.openshift.io/long-description: This template defines resources needed
+      to develop Red Hat Enterprise Application Server 7.1 based application, including
+      a build configuration, application deployment configuration and insecure communication
+      using http.
+    template.openshift.io/support-url: https://access.redhat.com
+    version: 1.4.17
+  creationTimestamp: 2019-08-12T09:10:09Z
+  name: eap71-basic-s2i
+  namespace: openshift
+  resourceVersion: "1545"
+  selfLink: /apis/template.openshift.io/v1/namespaces/openshift/templates/eap71-basic-s2i
+  uid: fc09a88e-bce0-11e9-8274-0ad64299291c
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The web server's http port.
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    ports:
+    - port: 8080
+      targetPort: 8080
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The JGroups ping port for clustering.
+      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}-ping
+  spec:
+    clusterIP: None
+    ports:
+    - name: ping
+      port: 8888
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}
+- apiVersion: v1
+  id: ${APPLICATION_NAME}-http
+  kind: Route
+  metadata:
+    annotations:
+      description: Route for application's http service.
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    host: ${HOSTNAME_HTTP}
+    to:
+      name: ${APPLICATION_NAME}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${APPLICATION_NAME}:latest
+    source:
+      contextDir: ${CONTEXT_DIR}
+      git:
+        ref: ${SOURCE_REPOSITORY_REF}
+        uri: ${SOURCE_REPOSITORY_URL}
+      type: Git
+    strategy:
+      sourceStrategy:
+        env:
+        - name: MAVEN_MIRROR_URL
+          value: ${MAVEN_MIRROR_URL}
+        - name: MAVEN_ARGS_APPEND
+          value: ${MAVEN_ARGS_APPEND}
+        - name: ARTIFACT_DIR
+          value: ${ARTIFACT_DIR}
+        forcePull: true
+        from:
+          kind: ImageStreamTag
+          name: jboss-eap71-openshift:1.3
+          namespace: ${IMAGE_STREAM_NAMESPACE}
+      type: Source
+    triggers:
+    - github:
+        secret: ${GITHUB_WEBHOOK_SECRET}
+      type: GitHub
+    - generic:
+        secret: ${GENERIC_WEBHOOK_SECRET}
+      type: Generic
+    - imageChange: {}
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    replicas: 1
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          application: ${APPLICATION_NAME}
+          deploymentConfig: ${APPLICATION_NAME}
+        name: ${APPLICATION_NAME}
+      spec:
+        containers:
+        - env:
+          - name: HOTROD_PASSWORD
+            value: ${HOTROD_PASSWORD}
+          - name: HOTROD_USER
+            value: ${HOTROD_USER}
+          - name: HOTROD_SERVICE
+            value: ${HOTROD_SERVICE}
+          - name: HOTROD_SERVICE_PORT
+            value: ${HOTROD_SERVICE_PORT}
+          - name: APP_NAME
+            value: ${APP_NAME}
+          - name: USE_KUBE_TRUSTSTORE
+            value: ${USE_KUBE_TRUSTSTORE}
+          - name:  TRUSTSTORE_PATH
+            value: ${TRUSTSTORE_PATH}
+          - name:  TRUSTSTORE_PASSWORD
+            value:  ${TRUSTSTORE_PASSWORD}
+
+
+          - name: JGROUPS_PING_PROTOCOL
+            value: openshift.DNS_PING
+          - name: OPENSHIFT_DNS_PING_SERVICE_NAME
+            value: ${APPLICATION_NAME}-ping
+          - name: OPENSHIFT_DNS_PING_SERVICE_PORT
+            value: "8888"
+          - name: MQ_CLUSTER_PASSWORD
+            value: ${MQ_CLUSTER_PASSWORD}
+          - name: MQ_QUEUES
+            value: ${MQ_QUEUES}
+          - name: MQ_TOPICS
+            value: ${MQ_TOPICS}
+          - name: JGROUPS_CLUSTER_PASSWORD
+            value: ${JGROUPS_CLUSTER_PASSWORD}
+          - name: AUTO_DEPLOY_EXPLODED
+            value: ${AUTO_DEPLOY_EXPLODED}
+          image: ${APPLICATION_NAME}
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - /opt/eap/bin/livenessProbe.sh
+            initialDelaySeconds: 60
+          name: ${APPLICATION_NAME}
+          ports:
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 8888
+            name: ping
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - /opt/eap/bin/readinessProbe.sh
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+        terminationGracePeriodSeconds: 75
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${APPLICATION_NAME}
+        from:
+          kind: ImageStreamTag
+          name: ${APPLICATION_NAME}:latest
+      type: ImageChange
+    - type: ConfigChange
+parameters:
+- description: The name for the application.
+  displayName: Application Name
+  name: APPLICATION_NAME
+  required: true
+  value: hotrod-client
+- description: 'Custom hostname for http service route.  Leave blank for default hostname,
+    e.g.: <application-name>-<project>.<default-domain-suffix>'
+  displayName: Custom http Route Hostname
+  name: HOSTNAME_HTTP
+- description: Git source URI for application
+  displayName: Git Repository URL
+  name: SOURCE_REPOSITORY_URL
+  required: true
+  value: https://github.com/sergiordlr/temp-testfiles.git
+- description: Git branch/tag reference
+  displayName: Git Reference
+  name: SOURCE_REPOSITORY_REF
+  value: master
+- description: Path within Git project to build; empty for root project directory.
+  displayName: Context Directory
+  name: CONTEXT_DIR
+  value: datagrid-client
+- description: Queue names
+  displayName: Queues
+  name: MQ_QUEUES
+- description: Topic names
+  displayName: Topics
+  name: MQ_TOPICS
+- description: A-MQ cluster admin password
+  displayName: A-MQ cluster password
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: MQ_CLUSTER_PASSWORD
+  required: true
+- description: GitHub trigger secret
+  displayName: Github Webhook Secret
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: GITHUB_WEBHOOK_SECRET
+  required: true
+- description: Generic build trigger secret
+  displayName: Generic Webhook Secret
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: GENERIC_WEBHOOK_SECRET
+  required: true
+- description: Namespace in which the ImageStreams for Red Hat Middleware images are
+    installed. These ImageStreams are normally installed in the openshift namespace.
+    You should only need to modify this if you've installed the ImageStreams in a
+    different namespace/project.
+  displayName: ImageStream Namespace
+  name: IMAGE_STREAM_NAMESPACE
+  required: true
+  value: openshift
+- description: JGroups cluster password
+  displayName: JGroups Cluster Password
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: JGROUPS_CLUSTER_PASSWORD
+  required: true
+- description: Controls whether exploded deployment content should be automatically
+    deployed
+  displayName: Deploy Exploded Archives
+  name: AUTO_DEPLOY_EXPLODED
+  value: "false"
+- description: Maven mirror to use for S2I builds
+  displayName: Maven mirror URL
+  name: MAVEN_MIRROR_URL
+- description: Maven additional arguments to use for S2I builds
+  displayName: Maven Additional Arguments
+  name: MAVEN_ARGS_APPEND
+  value: -Dcom.redhat.xpaas.repo.jbossorg
+- description: List of directories from which archives will be copied into the deployment
+    folder. If unspecified, all archives in /target will be copied.
+  name: ARTIFACT_DIR
+- description: Container memory limit
+  name: MEMORY_LIMIT
+  value: 1Gi
+
+
+
+- name: HOTROD_PASSWORD
+  value: "changeme"
+  description: Password used to authenticate the user in hot rod service.
+  required: true
+- name: HOTROD_USER
+  value: "test"
+  description: User used to authenticate for hotrod authentication.
+  required: true
+- name: HOTROD_SERVICE
+  value: datagrid-service
+  #value: datagrid-app-hotrod
+  description: The name of the hotrod service where hotrod is exposed.
+  required: true
+- name: HOTROD_SERVICE_PORT
+  value: "11222"
+  description: Port where hotrod is exposed.
+  required: true
+- name: APP_NAME
+  value: "datagrid-service"
+  #value: "jdg-server"
+  description: The name of the hotrod server.
+  required: true
+  
+
+- name: USE_KUBE_TRUSTSTORE
+  value: "true"
+  description: Generate they keystore from kubernetes internal certificate.
+- name: TRUSTSTORE_PATH
+  description: Path to the truststore file if not using the one generated from kubernetes internal certificate.
+- name: TRUSTSTORE_PASSWORD
+  value: ""
+  description: Password to be used with TRUSTSTORE_PATH file.

--- a/roles/ocp-24871-datagrid/tasks/deploy.yml
+++ b/roles/ocp-24871-datagrid/tasks/deploy.yml
@@ -1,0 +1,32 @@
+#- name: Check that datagrid-service application exists in openshift namespace as a template
+#  k8s_facts:
+#    api_version: template.openshift.io/v1
+#    kind: Template
+#    name: "datagrid-service"
+#    namespace: openshift
+#  register: app_template
+#  until: app_template.resources|length > 0
+#  retries: 3
+  
+- name: Check namespace
+  k8s_facts:
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: ns
+
+- name: Create namespace
+  shell: "{{ oc_binary }} new-project {{ namespace }} --skip-config-write=true"
+  when: ns.resources | length == 0
+
+- name: Create openshift datagrid application from openshift templates
+  shell: "{{ oc_binary }} -n {{ namespace }} new-app --template datagrid-service -p APPLICATION_USER={{ app_user }} -p APPLICATION_PASSWORD={{ app_password }} -p NUMBER_OF_INSTANCES={{ num_dg_instances }}"
+
+- name: Expose the application service via route
+  shell: "{{ oc_binary }} -n {{ namespace }} create route reencrypt datagrid-service-https --port=https --service datagrid-service"
+
+- name: Create a hot-rod basic client
+  shell: "{{ oc_binary }} process -f {{ hotrod_client_sourcecode }} -p HOTROD_PASSWORD={{ app_password }} -p HOTROD_USER={{ app_user }}  | {{ oc_binary }} -n {{ namespace }} create -f -"
+
+- name: Create a cronjob basic rest client
+  shell: "oc process -f {{ cronjob_insert_sourcecode }} -p CACHE={{ rest_cache_name }} -p CRON_NAME={{ cron_name }} -p DATAGRID_USERNAME={{ app_user }} -p DATAGRID_PASSWORD={{ app_password }} | oc -n {{ namespace }} create -f -"
+

--- a/roles/ocp-24871-datagrid/tasks/main.yml
+++ b/roles/ocp-24871-datagrid/tasks/main.yml
@@ -1,0 +1,24 @@
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate source
+  import_tasks: validate-source.yml
+  when: (with_validate|bool) and (with_deploy|bool)
+
+- name: Validate migration
+  import_tasks: validate-target.yml
+  when: (with_validate|bool) and (with_migrate|bool)

--- a/roles/ocp-24871-datagrid/tasks/migrate.yml
+++ b/roles/ocp-24871-datagrid/tasks/migrate.yml
@@ -1,0 +1,3 @@
+- name: Execute migration
+  include_role:
+    name: migration_run

--- a/roles/ocp-24871-datagrid/tasks/track.yml
+++ b/roles/ocp-24871-datagrid/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-24871-datagrid/tasks/validate-source.yml
+++ b/roles/ocp-24871-datagrid/tasks/validate-source.yml
@@ -1,0 +1,125 @@
+- name: Check datagrid pod status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "application=datagrid-service"
+    field_selectors: 
+    - status.phase=Running
+  register: pod
+  until : >-
+       pod.resources|default([])|length == num_dg_instances and
+       pod | json_query('resources[*].status.containerStatuses[*].ready') | flatten |difference( [true] ) | length  == 0
+  retries: 40
+
+
+- name: Check hotrod client pod status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "application=hotrod-client"
+    field_selectors: 
+    - status.phase=Running
+  register: pod
+  until : >-
+       pod.resources|default([])|length > 0 and
+       pod | json_query('resources[*].status.containerStatuses[*].ready') | flatten |difference( [true] ) | length  == 0
+  retries: 20
+  delay: 20
+
+- name: Get hotrod client route
+  k8s_facts:
+    kind: Route
+    namespace: "{{ namespace }}"
+    label_selectors: "application=hotrod-client"
+  register: hotrod_route
+  until: hotrod_route.resources|length > 0
+
+- name: Get datagrid service route
+  k8s_facts:
+    kind: Route
+    namespace: "{{ namespace }}"
+    label_selectors: "application=datagrid-service"
+  register: dg_route
+  until: dg_route.resources|length > 0
+
+
+- name: Use the hotrod client to create a cache that will be used to insert more data via hotrod
+  uri:
+    url:  http://{{ hotrod_route.resources[0].spec.host }}/datagridclient/dgcache
+    method: POST
+    body_format: form-urlencoded
+    body:
+      name: "{{ hotrod_cache_name }}"
+
+- name: Use the hotrod client to create a cache that will be used to insert more data via api rest
+  uri:
+    url:  http://{{ hotrod_route.resources[0].spec.host }}/datagridclient/dgcache
+    method: POST
+    body_format: form-urlencoded
+    body:
+      name: "{{ rest_cache_name }}"
+
+- name: Check cronjob status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "application={{ cron_name }}"
+    field_selectors:  
+    - status.phase=Succeeded 
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- name: Insert data in the hotrod cache
+  uri:
+    url:  http://{{ hotrod_route.resources[0].spec.host }}/datagridclient/insert 
+    method: POST
+    body_format: form-urlencoded
+    body:
+      cache: "{{ hotrod_cache_name }}"
+      key: "key-{{ item }}"
+      data: "datavalue-{{ item }}"
+  register: insert_rsp
+  until: insert_rsp.status == 200
+  loop: "{{ range(0, 10)|list }}"
+  loop_control:
+    label: "Inserted -> key-{{ item }} : datavalue-{{ item }}"
+
+
+
+- name: Retrieve data inserted in the hotrod cache
+  uri:
+    url:  http://{{ hotrod_route.resources[0].spec.host }}/datagridclient/show
+    return_content: yes
+    method: POST
+    body_format: form-urlencoded
+    body:
+      cache: "{{ hotrod_cache_name }}"
+  register: hotrod_rsp
+  until: hotrod_rsp.status == 200
+
+
+- name: Retrieve inserted data from rest api (cron inserted data)
+  uri:
+    url:  https://{{ dg_route.resources[0].spec.host }}/rest/{{ rest_cache_name }}
+    return_content: yes
+    validate_certs: false
+    user: "{{ app_user }}"
+    password: "{{ app_password }}"
+    force_basic_auth: yes
+  register: rest_rsp
+  until: rest_rsp.status == 200
+
+# The data inserted is retreived from the cache with this format
+# key-{{ item }} : datavalue-{{ item }}
+# like "key-0 : datavalue-0\nkey-1 : datavalue-1\n----"
+- name: Verify hotrod inserted data
+  fail:
+     msg: The inserted data cannot be found in hotrod cache
+  when: not hotrod_rsp.content is search( "key-" + item|string + " . datavalue-" + item|string )
+  loop: "{{ range(0, 10)|list }}"
+
+- name: Verify rest inserted data
+  fail:
+     msg: The inserted data cannot be found in rest cache
+  when: rest_rsp.content.splitlines()|length == 0

--- a/roles/ocp-24871-datagrid/tasks/validate-target.yml
+++ b/roles/ocp-24871-datagrid/tasks/validate-target.yml
@@ -1,0 +1,153 @@
+- name: Check datagrid pod status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "application=datagrid-service"
+    field_selectors: 
+    - status.phase=Running
+  register: pod
+  until : >-
+       pod.resources|default([])|length == num_dg_instances and
+       pod | json_query('resources[*].status.containerStatuses[*].ready') | flatten |difference( [true] ) | length  == 0
+  retries: 40
+
+- name: Get hotrod client route
+  k8s_facts:
+    kind: Route
+    namespace: "{{ namespace }}"
+    label_selectors: "application=hotrod-client"
+  register: hotrod_route
+  until: hotrod_route.resources|length > 0
+
+- name: Get datagrid service route
+  k8s_facts:
+    kind: Route
+    namespace: "{{ namespace }}"
+    label_selectors: "application=datagrid-service"
+  register: dg_route
+  until: dg_route.resources|length > 0
+
+# A cronjob can always insert any data, so we cannot be sure that this is the real data befor migration
+# because we cannot check the source cluster. Nevertheless, even if not accurate, this information should
+# be there in the cache. If not, then there was a problem with the volumes migration.
+- name: Retrieve the data inserted before the migration from rest api (cron inserted data)
+  uri:
+    url:  https://{{ dg_route.resources[0].spec.host }}/rest/{{ rest_cache_name }}
+    return_content: yes
+    validate_certs: false
+    user: "{{ app_user }}"
+    password: "{{ app_password }}"
+    force_basic_auth: yes
+  register: rest_rsp
+  until: rest_rsp.status == 200
+
+- name: Check hotrod client pod status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "application=hotrod-client"
+    field_selectors: 
+    - status.phase=Running
+  register: pod
+  until : >-
+       pod.resources|default([])|length > 0 and
+       pod | json_query('resources[*].status.containerStatuses[*].ready') | flatten |difference( [true] ) | length  == 0
+  retries: 20
+  delay: 20
+
+- name: Check cronjob status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "application={{ cron_name }}"
+    field_selectors:  
+    - status.phase=Succeeded 
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- name: Retrieve the data inserted before the migration in the hotrod cache
+  uri:
+    url:  http://{{ hotrod_route.resources[0].spec.host }}/datagridclient/show
+    return_content: yes
+    method: POST
+    body_format: form-urlencoded
+    body:
+      cache: "{{ hotrod_cache_name }}"
+  register: hotrod_rsp
+  until: hotrod_rsp.status == 200
+
+# The data inserted is retreived from the cache with this format
+# key-{{ index }} : datavalue-{{ index }}
+# like "key-0 : datavalue-0\nkey-1 : datavalue-1\n----"
+- name: Verify hotrod inserted data
+  fail:
+     msg: The data inserted before the migration cannot be found in hotrod cache
+  when: not hotrod_rsp.content is search( "key-" + index|string + " . datavalue-" + index|string )
+  loop: "{{ range(0, 9)|list }}"
+  loop_control:
+    index_var: index
+
+- name: Verify rest inserted data
+  fail:
+     msg: The data inserted before the migration cannot be found in rest cache
+  when: rest_rsp.content.splitlines()|length == 0
+
+- name: Insert again new data in the hotrod cache after the migration
+  uri:
+    url:  http://{{ hotrod_route.resources[0].spec.host }}/datagridclient/insert 
+    method: POST
+    body_format: form-urlencoded
+    body:
+      cache: "{{ hotrod_cache_name }}"
+      key: "key-{{ item }}"
+      data: "datavalue-{{ item }}"
+  register: insert_rsp
+  until: insert_rsp.status == 200
+  loop: "{{ range(10, 20)|list }}"
+  loop_control:
+    label: "Inserted -> key-{{ item }} : datavalue-{{ item }}"
+
+- name: Retrieve the data inserted after the migration in the hotrod cache
+  uri:
+    url:  http://{{ hotrod_route.resources[0].spec.host }}/datagridclient/show
+    return_content: yes
+    method: POST
+    body_format: form-urlencoded
+    body:
+      cache: "{{ hotrod_cache_name }}"
+  register: hotrod_rsp_after
+  until: hotrod_rsp_after.status == 200
+
+
+- name: Verify total hotrod inserted data
+  fail:
+     msg: The data inserted after the migration cannot be found in hotrod cache
+  when: not hotrod_rsp_after.content is search( "key-" + item|string + " . datavalue-" + item|string )
+  loop: "{{ range(0, 20)|list }}"
+
+- pause:
+    prompt: Wait 1 minute to make sure that at least one cronjob has inserted data in the rest cache
+    minutes: 1
+
+- name: Retrieve the data stored in the rest cache (cron inserted data)
+  uri:
+    url:  https://{{ dg_route.resources[0].spec.host }}/rest/{{ rest_cache_name }}
+    return_content: yes
+    validate_certs: false
+    user: "{{ app_user }}"
+    password: "{{ app_password }}"
+    force_basic_auth: yes
+  register: rest_rsp_after
+  until: rest_rsp_after.status == 200
+
+- name: Data inserted by cronjobs before migration
+  debug: msg={{ rest_rsp.content.splitlines() }}
+
+- name: Total data inserted by crojobs
+  debug: msg={{ rest_rsp_after.content.splitlines() }}
+
+- name: Verify total rest inserted data
+  fail:
+     msg: Data is not being inserted in the rest cache by the cronjobs. Rest cache content should be growing
+  when: rest_rsp.content.splitlines()|length >= rest_rsp_after.content.splitlines()|length


### PR DESCRIPTION
Add ocp-24871-datagrid

1. Creates a datagrid-service application using the datagrid-service template stored in "openshift" namespace
2. Build a small client application that can communicate with the datagrid service in order to create caches and populate them using the hotrod interface.
3. Creates a cronjob that will use curl to make http requests to the datagrid-service api rest to populate a cache every minute with new information.
4. Migrates the namespace that contains all of this.
5. Verify that after the migration the old data is still there, and that we can insert new data.


Hotrod communication is done using the certificates stored in the datagrid-service via https. This test, apart from verifying that datagrid is actually being migrated properly, checks that services with `service.alpha.openshift.io/serving-cert-secret-name` annotation are handled properly too.