### PR TITLE
[DO NOT MERGE] Automate test case ocp-25022

### DIFF
--- a/e2e_mig_samples.yml
+++ b/e2e_mig_samples.yml
@@ -23,6 +23,7 @@
     - { role: ocp-26160-max-pvs, tags: ["ocp-26160-max-pvs", "ocp"] }
     - { role: ocp-24787-redis, tags: ["ocp-24787-redis", "ocp"] }
     - { role: ocp-24797-mongodb, tags: ["ocp-24797-mongodb", "ocp"] }
+    - { role: ocp-25022-cronjob-quiesced, tags: ["ocp-25022-cronjob-quiesced", "ocp"] }
   vars_files:
     - "{{ playbook_dir }}/config/mig_controller.yml"
     - "{{ playbook_dir }}/config/defaults.yml"

--- a/roles/ocp-25022-cronjob-quiesced/defaults/main.yml
+++ b/roles/ocp-25022-cronjob-quiesced/defaults/main.yml
@@ -1,7 +1,7 @@
 namespace: ocp-25022-cronjob-quiesced 
 
-app_name: hellocron
-docker_image: docker.io/alpine
+cur_app_name: hellocron
+cur_docker_image: docker.io/alpine
 
 migration_sample_name: "{{ namespace }}"
 migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"

--- a/roles/ocp-25022-cronjob-quiesced/defaults/main.yml
+++ b/roles/ocp-25022-cronjob-quiesced/defaults/main.yml
@@ -1,0 +1,15 @@
+namespace: ocp-25022-cronjob-quiesced 
+
+app_name: hellocron
+docker_image: docker.io/alpine
+
+migration_sample_name: "{{ namespace }}"
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: true 
+

--- a/roles/ocp-25022-cronjob-quiesced/tasks/deploy.yml
+++ b/roles/ocp-25022-cronjob-quiesced/tasks/deploy.yml
@@ -1,9 +1,20 @@
+- name: Check namespace
+  k8s_facts:
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: ns
+
+- name: Create namespace
+  shell: "{{ oc_binary }} new-project {{ migration_sample_name }} --skip-config-write=true"
+  when: ns.resources | length == 0
+
+
 - name: Deploy simple hello world cron job using external image in migration source cluster {{ migcluster_source_name }}
   k8s:
     state : present
     namespace : "{{ migration_sample_name }}"
     definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
   vars:
-    app_name: "{{ app_name }}"
-    docker_image: "{{ docker_image }}" 
+    app_name: "{{ cur_app_name }}"
+    docker_image: "{{ cur_docker_image }}" 
 

--- a/roles/ocp-25022-cronjob-quiesced/tasks/deploy.yml
+++ b/roles/ocp-25022-cronjob-quiesced/tasks/deploy.yml
@@ -1,0 +1,9 @@
+- name: Deploy simple hello world cron job using external image in migration source cluster {{ migcluster_source_name }}
+  k8s:
+    state : present
+    namespace : "{{ migration_sample_name }}"
+    definition: "{{ lookup('template', 'deployment.yml.j2' )}}"
+  vars:
+    app_name: "{{ app_name }}"
+    docker_image: "{{ docker_image }}" 
+

--- a/roles/ocp-25022-cronjob-quiesced/tasks/main.yml
+++ b/roles/ocp-25022-cronjob-quiesced/tasks/main.yml
@@ -1,0 +1,25 @@
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate source
+  import_tasks: validate-source.yml
+  when: (with_validate|bool) and (with_deploy|bool)
+
+- name: Validate migration
+  import_tasks: validate-target.yml
+  when: (with_validate|bool) and (with_migrate|bool)
+

--- a/roles/ocp-25022-cronjob-quiesced/tasks/migrate.yml
+++ b/roles/ocp-25022-cronjob-quiesced/tasks/migrate.yml
@@ -1,0 +1,4 @@
+- name: Execute migration
+  include_role:
+    name: migration_run
+

--- a/roles/ocp-25022-cronjob-quiesced/tasks/track.yml
+++ b/roles/ocp-25022-cronjob-quiesced/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-25022-cronjob-quiesced/tasks/validate-source.yml
+++ b/roles/ocp-25022-cronjob-quiesced/tasks/validate-source.yml
@@ -1,0 +1,45 @@
+- name: check cronjob status in source cluster {{ migcluster_source_name }}
+  k8s_facts:
+    api_version: batch/v1beta1
+    kind: CronJob 
+    namespace: "{{ migration_sample_name }}"
+  register:  cronjob_info 
+  until: cronjob_info.resources | length > 0
+  retries: 30
+ 
+- debug:
+    msg: "{{ cronjob_info }}"  
+
+- name: sleep 1 minute to wait cron job to run
+  shell: sleep 60
+
+- name: Check app {{ app_name }} pod status
+  k8s_facts:
+    api_version: v1 
+    kind: Pod
+    namespace: "{{ migration_sample_name }}"
+    label_selectors: "cronowner={{ app_name }}"
+    field_selectors: 
+    - status.phase=Succeeded
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- debug:
+    msg: "{{ pod }}"
+
+- name: get  the lof of cron job
+  shell: oc logs $(oc get pod -n cronquiesced-test|grep Completed|tail -1|awk '{print $1}')
+  register: cronjob_log
+
+- debug:
+    msg: "{{ cronjob_log }}"
+
+- name: set expected log string
+  set_fact:
+     expected_log_str: "Hello! from namespace{{ migration_sample_name }} while using image {{ docker_image }}"
+
+- name: check the log of cron job
+   fail:
+     msg: "the log of cron job is wrong"
+   when: "expected_log_str not in cronjob_log.stdout"

--- a/roles/ocp-25022-cronjob-quiesced/tasks/validate-source.yml
+++ b/roles/ocp-25022-cronjob-quiesced/tasks/validate-source.yml
@@ -13,12 +13,12 @@
 - name: sleep 1 minute to wait cron job to run
   shell: sleep 60
 
-- name: Check app {{ app_name }} pod status
+- name: Check app {{ cur_app_name }} pod status
   k8s_facts:
     api_version: v1 
     kind: Pod
     namespace: "{{ migration_sample_name }}"
-    label_selectors: "cronowner={{ app_name }}"
+    label_selectors: "cronowner={{ cur_app_name }}"
     field_selectors: 
     - status.phase=Succeeded
   register: pod
@@ -28,8 +28,9 @@
 - debug:
     msg: "{{ pod }}"
 
-- name: get  the lof of cron job
-  shell: oc logs $(oc get pod -n cronquiesced-test|grep Completed|tail -1|awk '{print $1}')
+- name: get  the log of cron job
+  #shell: oc logs $(oc get pod -n {{ migration_sample_name }}|grep Completed|tail -1|awk '{print $1}') -n {{ migration_sample_name }}
+  shell: oc logs $(oc get pod -n {{ migration_sample_name }}|tail -1|awk '{print $1}') -n {{ migration_sample_name }}
   register: cronjob_log
 
 - debug:
@@ -37,9 +38,9 @@
 
 - name: set expected log string
   set_fact:
-     expected_log_str: "Hello! from namespace{{ migration_sample_name }} while using image {{ docker_image }}"
+    expected_log_str: "Hello! from namespace {{ migration_sample_name }} while using image {{ cur_docker_image }}"
 
 - name: check the log of cron job
-   fail:
-     msg: "the log of cron job is wrong"
-   when: "expected_log_str not in cronjob_log.stdout"
+  fail:
+    msg: "the log of cron job is wrong"
+  when: "expected_log_str not in cronjob_log.stdout"

--- a/roles/ocp-25022-cronjob-quiesced/tasks/validate-target.yml
+++ b/roles/ocp-25022-cronjob-quiesced/tasks/validate-target.yml
@@ -1,3 +1,7 @@
+- name: set expected output for MigMigration
+  set_fact:
+    expected_string: "The migration has completed successfully"  
+
 - name: check the migmigration running status 
   k8s_facts:
     api_version: migration.openshift.io/v1alpha1 
@@ -6,7 +10,7 @@
     field_selectors:
       - metadata.name={{ migration_name }}
   register: mig_result 
-  until: "mig_result.resources[0].status.conditions.message is The migration has completed successfully."  
+  until: "expected_string in (mig_result| json_query('resources[0].status.conditions[].message')|string)"            
   retries: 30
 
 

--- a/roles/ocp-25022-cronjob-quiesced/tasks/validate-target.yml
+++ b/roles/ocp-25022-cronjob-quiesced/tasks/validate-target.yml
@@ -4,7 +4,7 @@
     kind: MigMigration 
     namespace: "{{ migration_namespace }}"
     field_selectors:
-      - metadata.name={{ metadata }}
+      - metadata.name={{ migration_name }}
   register: mig_result 
   until: "mig_result.resources[0].status.conditions.message is The migration has completed successfully."  
   retries: 30
@@ -25,12 +25,12 @@
 - name: sleep 1 minute to wait cron job to run
   shell: sleep 60
 
-- name: Check app {{ app_name }} pod status
+- name: Check app {{ cur_app_name }} pod status
   k8s_facts:
     api_version: v1 
     kind: Pod
     namespace: "{{ migration_sample_name }}"
-    label_selectors: "cronowner={{ app_name }}"
+    label_selectors: "cronowner={{ cur_app_name }}"
     field_selectors: 
     - status.phase=Succeeded
   register: pod
@@ -41,7 +41,7 @@
     msg: "{{ pod }}"
 
 - name: get  the lof of cron job
-  shell: oc logs $(oc get pod -n cronquiesced-test|grep Completed|tail -1|awk '{print $1}')
+  shell: oc logs $(oc get pod -n {{ migration_sample_name }}|grep Completed|tail -1|awk '{print $1}')  -n {{ migration_sample_name }}
   register: cronjob_log
 
 - debug:
@@ -49,12 +49,12 @@
 
 - name: set expected log string
   set_fact:
-     expected_log_str: "Hello! from namespace{{ migration_sample_name }} while using image {{ docker_image }}"
+     expected_log_str: "Hello! from namespace {{ migration_sample_name }} while using image {{ cur_docker_image }}"
 
 - name: check the log of cron job
-   fail:
+  fail:
      msg: "the log of cron job is wrong"
-   when: "expected_log_str not in cronjob_log.stdout"
+  when: "expected_log_str not in cronjob_log.stdout"
 
 #TODO: when possible, check that original cronjobs have not been quiesced.
 

--- a/roles/ocp-25022-cronjob-quiesced/tasks/validate-target.yml
+++ b/roles/ocp-25022-cronjob-quiesced/tasks/validate-target.yml
@@ -1,0 +1,60 @@
+- name: check the migmigration running status 
+  k8s_facts:
+    api_version: migration.openshift.io/v1alpha1 
+    kind: MigMigration 
+    namespace: "{{ migration_namespace }}"
+    field_selectors:
+      - metadata.name={{ metadata }}
+  register: mig_result 
+  until: "mig_result.resources[0].status.conditions.message is The migration has completed successfully."  
+  retries: 30
+
+
+- name: check cronjob status in target cluster {{ migcluster_target_name }}
+  k8s_facts:
+    api_version: batch/v1beta1
+    kind: CronJob 
+    namespace: "{{ migration_sample_name }}"
+  register:  cronjob_info 
+  until: cronjob_info.resources | length > 0
+  retries: 30
+ 
+- debug:
+    msg: "{{ cronjob_info }}"  
+
+- name: sleep 1 minute to wait cron job to run
+  shell: sleep 60
+
+- name: Check app {{ app_name }} pod status
+  k8s_facts:
+    api_version: v1 
+    kind: Pod
+    namespace: "{{ migration_sample_name }}"
+    label_selectors: "cronowner={{ app_name }}"
+    field_selectors: 
+    - status.phase=Succeeded
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- debug:
+    msg: "{{ pod }}"
+
+- name: get  the lof of cron job
+  shell: oc logs $(oc get pod -n cronquiesced-test|grep Completed|tail -1|awk '{print $1}')
+  register: cronjob_log
+
+- debug:
+    msg: "{{ cronjob_log }}"
+
+- name: set expected log string
+  set_fact:
+     expected_log_str: "Hello! from namespace{{ migration_sample_name }} while using image {{ docker_image }}"
+
+- name: check the log of cron job
+   fail:
+     msg: "the log of cron job is wrong"
+   when: "expected_log_str not in cronjob_log.stdout"
+
+#TODO: when possible, check that original cronjobs have not been quiesced.
+

--- a/roles/ocp-25022-cronjob-quiesced/templates/deployment.yml.j2
+++ b/roles/ocp-25022-cronjob-quiesced/templates/deployment.yml.j2
@@ -1,0 +1,35 @@
+apiVersion: v1
+items:
+- apiVersion: {{ cronjob_api }}
+  kind: CronJob
+  metadata:
+    labels:
+      app: '{{ app_name }}'
+    name: '{{ app_name }}'
+  spec:
+    jobTemplate:
+      metadata:
+        labels:
+          cronowner: '{{ app_name }}'
+      spec:
+        template:
+          metadata:
+            labels:
+              cronowner: '{{ app_name }}'
+          spec:
+            containers:
+            - args:
+              - /bin/sh
+              - -c
+              - echo "Hello! from namespace $CURRENT_NAMESPACE while using image {{ docker_image }}"
+              env:
+              - name: CURRENT_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              image: '{{ docker_image }}'
+              name: '{{ app_name }}'
+            restartPolicy: OnFailure
+    schedule: '*/1 * * * *'
+kind: List
+metadata: {}

--- a/roles/ocp-25022-cronjob-quiesced/templates/deployment.yml.j2
+++ b/roles/ocp-25022-cronjob-quiesced/templates/deployment.yml.j2
@@ -1,6 +1,6 @@
 apiVersion: v1
 items:
-- apiVersion: {{ cronjob_api }}
+- apiVersion: batch/v1beta1
   kind: CronJob
   metadata:
     labels:


### PR DESCRIPTION
Auto test case for [ocp-25022](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-25022)

The logic of this test are:
* create a crontab job in source cluster
* create a migration plan and migrate the crontab job from source cluster to target cluster with ``quiescePods: true`` option.
*  To check if the migration complete successfully.
*  **To check if the cronjob on source cluster goes to** ``SUSPEND`` **stage**. 

Due to the framework of current ansible automation tool just support below test process
* Deploy test data in source cluster then do some check against source cluster
* Migrate test data from source cluster to target cluster,  then do some check against target cluster. 

So **CAN NOT** achieve the 4th check step in current framework.  

The code in this PR has covered the first 3 steps of test logic of ocp-25022.  Due to can not cover all test logic, so suspend current PR until finding out better solution. 

