### PR TITLE
Add ocp-28021-istags testcase

### DIFF
--- a/roles/ocp-28021-istags/defaults/main.yml
+++ b/roles/ocp-28021-istags/defaults/main.yml
@@ -1,0 +1,37 @@
+namespace: ocp-28021-istags
+
+
+image_streams:
+- external_image_name: docker.io/alpine
+  internal_image_name: internal-alpine
+  internal_image_tag: int
+  external_image_tag: latest
+  extra_tags:
+  - name: tag1
+    alias: false
+  - name: tag2
+    alias: true
+- external_image_name: docker.io/alpine
+  internal_image_name: internal-alpine
+  internal_image_tag: 3.9
+  external_image_tag: 3.9
+  extra_tags:
+  - name: tag3
+    alias: false
+  - name: latest
+    alias: false
+  - name: tag4
+    alias: true
+
+
+
+migration_sample_name: ocp-28021-istags
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+#migration_sample_files: "{{ playbook_dir }}/mig-controller/docs/scenarios/{{ migration_sample_name }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: true

--- a/roles/ocp-28021-istags/tasks/deploy.yml
+++ b/roles/ocp-28021-istags/tasks/deploy.yml
@@ -1,0 +1,21 @@
+- name: Check namespace
+  k8s_facts:
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: ns
+
+- name: Create namespace
+  shell: "{{ oc_binary }} new-project {{ namespace }} --skip-config-write=true"
+  when: ns.resources | length == 0
+
+- name: Import image to imagestream
+  shell: "{{ oc_binary }} -n {{ namespace }}  import-image {{ item.internal_image_name }}:{{ item.internal_image_tag }} --from {{ item.external_image_name }}:{{ item.external_image_tag }} --confirm"
+  loop: "{{ image_streams }}"
+  loop_control:
+    label: "{{ oc_binary }} -n {{ namespace }}  import-image {{ item.internal_image_name }}:{{ item.internal_image_tag }} --from {{ item.external_image_name }}:{{ item.external_image_tag }} --confirm"
+
+- name: Tag the imported images
+  shell: "{{ oc_binary }} -n  {{ namespace }} tag {{ item.0.internal_image_name }}:{{ item.0.internal_image_tag }}  {{ item.0.internal_image_name }}:{{ item.1.name }} --alias={{item.1.alias}}"
+  loop: "{{ image_streams|subelements('extra_tags') }}"
+  loop_control:
+    label: "{{ oc_binary }} -n  {{ namespace }} tag {{ item.0.internal_image_name }}:{{ item.0.internal_image_tag }}  {{ item.0.internal_image_name }}:{{ item.1.name }} --alias={{item.1.alias}}"

--- a/roles/ocp-28021-istags/tasks/main.yml
+++ b/roles/ocp-28021-istags/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate migration
+  import_tasks: validate.yml
+  when: with_validate|bool

--- a/roles/ocp-28021-istags/tasks/migrate.yml
+++ b/roles/ocp-28021-istags/tasks/migrate.yml
@@ -1,0 +1,3 @@
+- name: Execute migration
+  include_role:
+    name: migration_run

--- a/roles/ocp-28021-istags/tasks/track.yml
+++ b/roles/ocp-28021-istags/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-28021-istags/tasks/validate.yml
+++ b/roles/ocp-28021-istags/tasks/validate.yml
@@ -1,0 +1,35 @@
+- name: Check image streams
+  k8s_facts:
+    kind: ImageStream
+    namespace: "{{ namespace }}"
+    name: "{{ item.internal_image_name }}"
+  register: imagestream
+  until: imagestream.get('resources',[]) | length == 1
+  retries: 10
+  loop: "{{ image_streams }}"
+  loop_control:
+    label: "Check that imagestream {{ item.internal_image_name }} exists"
+
+- name: Check initial tags
+  k8s_facts:
+    kind: ImageStreamTag
+    namespace: "{{ namespace }}"
+    name: "{{ item.internal_image_name }}:{{ item.internal_image_tag }}"
+  register: istag
+  until: istag.get('resources',[]) | length == 1
+  retries: 10
+  loop: "{{ image_streams }}"
+  loop_control:
+    label: "Check that imagestream tag {{ item.internal_image_name}}:{{item.internal_image_tag }} exists"
+
+- name: Check extra tags
+  k8s_facts:
+    kind: ImageStreamTag
+    namespace: "{{ namespace }}"
+    name: "{{ item.0.internal_image_name }}:{{ item.1.name }}"
+  register: istag
+  until: istag.get('resources',[]) | length == 1
+  retries: 10
+  loop: "{{ image_streams|subelements('extra_tags') }}"
+  loop_control:
+    label: "Check that imagestream tag {{ item.0.internal_image_name}}:{{item.1.name }} exists"


### PR DESCRIPTION
Add a new testcase to validate that imagestream tags can be migrated properly

1. Import an external image creating a imagestream and tags it
2. Add extra tags to this image
3. Import a new version of the image to this image stream
4. Add new tags to the new version
5. Migrate
6. Validate that the imagestream and its tags are OK after the migration.
