### PR TITLE
Fix ocp-24787-redis to work with 4.4 target clusters

### DIFF
--- a/roles/ocp-24787-redis/defaults/main.yml
+++ b/roles/ocp-24787-redis/defaults/main.yml
@@ -1,6 +1,7 @@
 namespace: ocp-24787-redis
 
 redis_password: "PASSWORD"
+redis_version: "latest"
 
 migration_sample_name: "{{ namespace }}"
 migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"

--- a/roles/ocp-24787-redis/files/redis.cmds
+++ b/roles/ocp-24787-redis/files/redis.cmds
@@ -1,2 +1,3 @@
 append mytestkey "Hello"
 append mytestkey " world!"
+SAVE

--- a/roles/ocp-24787-redis/tasks/deploy.yml
+++ b/roles/ocp-24787-redis/tasks/deploy.yml
@@ -9,4 +9,4 @@
   when: ns.resources | length == 0
 
 - name: Create openshift redis application from openshift templates
-  shell: "{{ oc_binary }} -n {{ namespace }} new-app --template redis-persistent -p REDIS_PASSWORD={{ redis_password }}"
+  shell: "{{ oc_binary }} -n {{ namespace }} new-app --template redis-persistent -p REDIS_PASSWORD={{ redis_password }} -p REDIS_VERSION={{ redis_version }}"

--- a/roles/ocp-24787-redis/tasks/validate-source.yml
+++ b/roles/ocp-24787-redis/tasks/validate-source.yml
@@ -2,7 +2,7 @@
   k8s_facts:
     kind: Pod
     namespace: "{{ namespace }}"
-    label_selectors: "app=redis-persistent"
+    label_selectors: "name=redis"
     field_selectors: 
     - status.phase=Running
   register: pod

--- a/roles/ocp-24787-redis/tasks/validate-target.yml
+++ b/roles/ocp-24787-redis/tasks/validate-target.yml
@@ -2,7 +2,7 @@
   k8s_facts:
     kind: Pod
     namespace: "{{ namespace }}"
-    label_selectors: "app=redis-persistent"
+    label_selectors: "name=redis"
     field_selectors: 
     - status.phase=Running
   register: pod


### PR DESCRIPTION
Redis version 3.2 has been removed from ocp 4.4, hence the migration fails when the target cluster is 4.4.

This PR changes the redis version to `latest` as default, and makes it configurable via `-e redis_version=$MYVERSION` parameter when executing the testcase.