### PR TITLE
[DO NOT MERGE] Automate TC 28597 

### DIFF
--- a/e2e_mig_samples.yml
+++ b/e2e_mig_samples.yml
@@ -23,6 +23,7 @@
     - { role: ocp-26160-max-pvs, tags: ["ocp-26160-max-pvs", "ocp"] }
     - { role: ocp-24787-redis, tags: ["ocp-24787-redis", "ocp"] }
     - { role: ocp-24797-mongodb, tags: ["ocp-24797-mongodb", "ocp"] }
+    - { role: ocp-28597-metrics, tags: ["ocp-28597-metrics", "ocp"] }
   vars_files:
     - "{{ playbook_dir }}/config/mig_controller.yml"
     - "{{ playbook_dir }}/config/defaults.yml"

--- a/roles/ocp-28597-metrics/defaults/main.yml
+++ b/roles/ocp-28597-metrics/defaults/main.yml
@@ -1,0 +1,12 @@
+namespace: ocp-28597-metrics 
+
+migration_sample_name: "{{ namespace }}"
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: false
+

--- a/roles/ocp-28597-metrics/tasks/main.yml
+++ b/roles/ocp-28597-metrics/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: Validate metrics work 
+  import_tasks: validate-target.yml
+  when: (with_validate|bool) and (with_migrate|bool)
+

--- a/roles/ocp-28597-metrics/tasks/validate-target.yml
+++ b/roles/ocp-28597-metrics/tasks/validate-target.yml
@@ -1,10 +1,13 @@
 - name: Add label to namespace {{ migration_namespace }} 
-  shell: "{{ oc_binary }} label ns {{ migration_namespace }}openshift-migration openshift.io/cluster-monitoring=true"
+  shell: "{{ oc_binary }} label ns {{ migration_namespace }} openshift.io/cluster-monitoring=true"
 
 
 - name: To get namespace {{ migration_namespace }} definition
   shell: "{{ oc_binary }} get ns {{ migration_namespace }} -o yaml"
   register: output
+
+- debug:
+    msg: "{{ output }}"
 
 - fail:
     msg: "Add label openshift.io/cluster-monitoring=true to ns {{ migration_namespace }} failed"
@@ -12,9 +15,15 @@
 
  
 - name: To get metrics from migration-controller pod 
-  shell: {{ oc_binary }} -n {{ migration_namespace }} rsh $({{ oc_binary }} get pod -n {{ migration_namespace }}|awk '/migration-controller/ {print $1}') curl  http://mig-controller-metrics.openshift-migration.svc.cluster.local:2112/metrics
+  shell: "{{ oc_binary }} -n {{ migration_namespace }} rsh $({{ oc_binary }} get pod -n {{ migration_namespace }}|awk '/migration-controller/ {print $1}') curl  http://mig-controller-metrics.openshift-migration.svc.cluster.local:2112/metrics"
   register: metrics_info  
 
 
 - debug:
     msg: "{{ metrics_info }}"
+
+
+- fail:
+    msg: "Failed to get cam_app_workload_migrations metrics from migration-controller pod"
+  when: not (metrics_info.stdout is search("cam_app_workload_migrations"))
+

--- a/roles/ocp-28597-metrics/tasks/validate-target.yml
+++ b/roles/ocp-28597-metrics/tasks/validate-target.yml
@@ -1,0 +1,20 @@
+- name: Add label to namespace {{ migration_namespace }} 
+  shell: "{{ oc_binary }} label ns {{ migration_namespace }}openshift-migration openshift.io/cluster-monitoring=true"
+
+
+- name: To get namespace {{ migration_namespace }} definition
+  shell: "{{ oc_binary }} get ns {{ migration_namespace }} -o yaml"
+  register: output
+
+- fail:
+    msg: "Add label openshift.io/cluster-monitoring=true to ns {{ migration_namespace }} failed"
+  when: not (output.stdout is search("openshift.io/cluster-monitoring"))
+
+ 
+- name: To get metrics from migration-controller pod 
+  shell: {{ oc_binary }} -n {{ migration_namespace }} rsh $({{ oc_binary }} get pod -n {{ migration_namespace }}|awk '/migration-controller/ {print $1}') curl  http://mig-controller-metrics.openshift-migration.svc.cluster.local:2112/metrics
+  register: metrics_info  
+
+
+- debug:
+    msg: "{{ metrics_info }}"


### PR DESCRIPTION
This is automatic test case for [TC28597](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-28597)

This test case is used to test CAM and Prometheus integration. Customer can leverage this feature to have better visibility on how successful when migrating their applications.

After deploying CAM (version >=1.1.2), 
The steps of TC28597 are 
* Add label `openshift.io/cluster-monitoring: "true"` to namespace `openshift-migration`
* Check if `service/mig-controller-metrics` is running
* Check if `metrics` can be expose from API `http://mig-controller-metrics.openshift-migration.svc.cluster.local:2112/metrics`
* Check if can query `metrics` from OCP monitoring prometheus web console. this step won't be covered by automation.