### PR TITLE
Automate TC OCP-27335 check velero version

### DIFF
--- a/roles/ocp-27335-velero-version/defaults/main.yml
+++ b/roles/ocp-27335-velero-version/defaults/main.yml
@@ -1,0 +1,10 @@
+namespace: ocp-27335-velero-version 
+
+migration_sample_name: "{{ namespace }}"
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+

--- a/roles/ocp-27335-velero-version/tasks/main.yml
+++ b/roles/ocp-27335-velero-version/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Validate source
+  import_tasks: validate-source.yml
+  when: (with_validate|bool) and (with_deploy|bool)
+
+- name: Validate migration
+  import_tasks: validate-target.yml
+  when: (with_validate|bool) and (with_migrate|bool)
+

--- a/roles/ocp-27335-velero-version/tasks/validate-source.yml
+++ b/roles/ocp-27335-velero-version/tasks/validate-source.yml
@@ -1,23 +1,23 @@
 - name: To check velero pod is running
-  shell: "{{ oc_binary }} get pod -n {{ namespace }}"
+  shell: "{{ oc_binary }} get pod -n {{ migration_namespace }}"
   register: pod_info
 
 - debug:
     msg: "{{ pod_info }}"
 
 - fail:
-    msg: "Failed to import imagestreams internal-image in namespace {{ namespace }}"
+    msg: "Failed to import imagestreams internal-image in namespace {{ migration_namespace }}"
   when: not (pod_info.stdout is search("velero"))
 
 - name: To check if can get velero version from velero pod
-  shell: "{{ oc_binary }} -n {{ migration_namespace }} rsh $({{ oc_binary }} get pod -n {{ migration_namespace }}|awk '/velero/ {print $1}') velero version -n {{ migration_namespace }}"
+  shell: "{{ oc_binary }} -n {{ migration_namespace }} rsh $({{ oc_binary }} get pod -n {{ migration_namespace }}|awk '/velero/ {print $1}') /velero version" 
   register: velero_info 
 
 - debug:
     msg: "{{ velero_info }}"
 
-- fail:
-    msg: "Failed to import imagestreams internal-image in namespace {{ namespace }}"
-  when: not (velero_info.stdout is search("Version: v"))
- 
 
+- fail:
+    msg: "Failed to import imagestreams internal-image in namespace {{ migration_namespace }}"
+  when: not (velero_info.stdout is search("Version.*v")) 
+ 

--- a/roles/ocp-27335-velero-version/tasks/validate-source.yml
+++ b/roles/ocp-27335-velero-version/tasks/validate-source.yml
@@ -1,0 +1,23 @@
+- name: To check velero pod is running
+  shell: "{{ oc_binary }} get pod -n {{ namespace }}"
+  register: pod_info
+
+- debug:
+    msg: "{{ pod_info }}"
+
+- fail:
+    msg: "Failed to import imagestreams internal-image in namespace {{ namespace }}"
+  when: not (pod_info.stdout is search("velero"))
+
+- name: To check if can get velero version from velero pod
+  shell: "{{ oc_binary }} -n {{ migration_namespace }} rsh $({{ oc_binary }} get pod -n {{ migration_namespace }}|awk '/velero/ {print $1}') velero version -n {{ migration_namespace }}"
+  register: velero_info 
+
+- debug:
+    msg: "{{ velero_info }}"
+
+- fail:
+    msg: "Failed to import imagestreams internal-image in namespace {{ namespace }}"
+  when: not (velero_info.stdout is search("Version: v"))
+ 
+

--- a/roles/ocp-27335-velero-version/tasks/validate-target.yml
+++ b/roles/ocp-27335-velero-version/tasks/validate-target.yml
@@ -1,23 +1,23 @@
 - name: To check velero pod is running
-  shell: "{{ oc_binary }} get pod -n {{ namespace }}"
+  shell: "{{ oc_binary }} get pod -n {{ migration_namespace }}"
   register: pod_info
 
 - debug:
     msg: "{{ pod_info }}"
 
 - fail:
-    msg: "Failed to import imagestreams internal-image in namespace {{ namespace }}"
+    msg: "Failed to import imagestreams internal-image in namespace {{ migration_namespace }}"
   when: not (pod_info.stdout is search("velero"))
 
 - name: To check if can get velero version from velero pod
-  shell: "{{ oc_binary }} -n {{ migration_namespace }} rsh $({{ oc_binary }} get pod -n {{ migration_namespace }}|awk '/velero/ {print $1}') velero version -n {{ migration_namespace }}"
+  shell: "{{ oc_binary }} -n {{ migration_namespace }} rsh $({{ oc_binary }} get pod -n {{ migration_namespace }}|awk '/velero/ {print $1}') /velero version" 
   register: velero_info 
 
 - debug:
     msg: "{{ velero_info }}"
 
-- fail:
-    msg: "Failed to import imagestreams internal-image in namespace {{ namespace }}"
-  when: not (velero_info.stdout is search("Version: v"))
- 
 
+- fail:
+    msg: "Failed to import imagestreams internal-image in namespace {{ migration_namespace }}"
+  when: not (velero_info.stdout is search("Version.*v")) 
+ 

--- a/roles/ocp-27335-velero-version/tasks/validate-target.yml
+++ b/roles/ocp-27335-velero-version/tasks/validate-target.yml
@@ -1,0 +1,23 @@
+- name: To check velero pod is running
+  shell: "{{ oc_binary }} get pod -n {{ namespace }}"
+  register: pod_info
+
+- debug:
+    msg: "{{ pod_info }}"
+
+- fail:
+    msg: "Failed to import imagestreams internal-image in namespace {{ namespace }}"
+  when: not (pod_info.stdout is search("velero"))
+
+- name: To check if can get velero version from velero pod
+  shell: "{{ oc_binary }} -n {{ migration_namespace }} rsh $({{ oc_binary }} get pod -n {{ migration_namespace }}|awk '/velero/ {print $1}') velero version -n {{ migration_namespace }}"
+  register: velero_info 
+
+- debug:
+    msg: "{{ velero_info }}"
+
+- fail:
+    msg: "Failed to import imagestreams internal-image in namespace {{ namespace }}"
+  when: not (velero_info.stdout is search("Version: v"))
+ 
+


### PR DESCRIPTION
This PR is for TC OCP-27335  automation.

The logic of TC OCP-27335  is :
in CAM source and target cluster
* velero pod should run
* Can get velero version from velero pod
```
#oc rsh velero-57cd669bb9-thhxx velero version -n openshift-migration
Client:
Version: v1.2.0-konveyor
Git commit: -
Server:
Version: v1.2.0-konveyor
```