### PR TITLE
Automate TC ocp-24706 Verify volume migration basic file usage	

### DIFF
--- a/roles/ocp-24706-volume/defaults/main.yml
+++ b/roles/ocp-24706-volume/defaults/main.yml
@@ -1,0 +1,24 @@
+namespace: ocp-24706-volume 
+
+migration_sample_name: "{{ namespace }}"
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+quiesce: false
+
+
+pv: true
+pv_action: copy
+pv_copy_method: filesystem
+dst_storage_class: gp2 
+src_storageclass: gp2
+
+logs_accessmode: ReadWriteOnce
+logs_storageclass: "{{ src_storageclass }}" 
+html_accessmode: ReadWriteOnce
+html_storageclass: "{{ src_storageclass }}"
+ 
+

--- a/roles/ocp-24706-volume/tasks/deploy.yml
+++ b/roles/ocp-24706-volume/tasks/deploy.yml
@@ -1,9 +1,9 @@
 - name: Create in source cluster a nginx application with two persistent volumes
-  shell: "{{ oc_binary }} process -p LOGS_ACCESSMODE={{ logs_accessmode }}  -p LOGS_STORAGECLASS={{ logs_storageclass }}  -p HTML_ACCESSMODE={{ html_accessmode }} -p HTML_STORAGECLASS={{ html_storageclass }} -p NAMESPACE={{ namespace }} -f {{ playbook_dir }}/roles/{{ migration_sample_name }}/templates/nginx_with_pv_template.yml |oc create -f -
+  shell: "{{ oc_binary }} process -p LOGS_ACCESSMODE={{ logs_accessmode }}  -p LOGS_STORAGECLASS={{ logs_storageclass }}  -p HTML_ACCESSMODE={{ html_accessmode }} -p HTML_STORAGECLASS={{ html_storageclass }} -p NAMESPACE={{ namespace }} -f {{ playbook_dir }}/roles/{{ migration_sample_name }}/templates/nginx_with_pv_template.yml |oc create -f - "
   register: create_result
 
 
 - fail:
-    msg: "Create in source cluster a nginx application with two persistent volumes failed"
+   msg: "Create in source cluster a nginx application with two persistent volumes failed"
   when: create_result.rc != 0 
 

--- a/roles/ocp-24706-volume/tasks/deploy.yml
+++ b/roles/ocp-24706-volume/tasks/deploy.yml
@@ -1,0 +1,9 @@
+- name: Create in source cluster a nginx application with two persistent volumes
+  shell: "{{ oc_binary }} process -p LOGS_ACCESSMODE={{ logs_accessmode }}  -p LOGS_STORAGECLASS={{ logs_storageclass }}  -p HTML_ACCESSMODE={{ html_accessmode }} -p HTML_STORAGECLASS={{ html_storageclass }} -p NAMESPACE={{ namespace }} -f {{ playbook_dir }}/roles/{{ migration_sample_name }}/templates/nginx_with_pv_template.yml |oc create -f -
+  register: create_result
+
+
+- fail:
+    msg: "Create in source cluster a nginx application with two persistent volumes failed"
+  when: create_result.rc != 0 
+

--- a/roles/ocp-24706-volume/tasks/main.yml
+++ b/roles/ocp-24706-volume/tasks/main.yml
@@ -1,0 +1,25 @@
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate source
+  import_tasks: validate-source.yml
+  when: (with_validate|bool) and (with_deploy|bool)
+
+- name: Validate migration
+  import_tasks: validate-target.yml
+  when: (with_validate|bool) and (with_migrate|bool)
+

--- a/roles/ocp-24706-volume/tasks/migrate.yml
+++ b/roles/ocp-24706-volume/tasks/migrate.yml
@@ -1,0 +1,4 @@
+- name: Execute migration
+  include_role:
+    name: migration_run
+

--- a/roles/ocp-24706-volume/tasks/track.yml
+++ b/roles/ocp-24706-volume/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-24706-volume/tasks/validate-source.yml
+++ b/roles/ocp-24706-volume/tasks/validate-source.yml
@@ -11,16 +11,12 @@
   k8s_facts:
     api_version: v1
     kind: PersistentVolumeClaim
-    namespace: "{{ migration_sample_name }}"
-    label_selectors:
-    - app=nginx
+    namespace: "{{ namespace }}"
+    label_selectors: "app=nginx"
     field_selectors:
     - metadata.name=nginx-html
-    - spec.storageClassName={{ html_storageclass }}
-    - status.accessModes={{ html_accessmode }}
-    - status.phase=Bound 
   register: html_pv 
-  until: html_pv.resources | length > 0
+  until: html_pv.get("resources", []) and html_pv.resources[0].get("status", {}).get("phase", "") == "Bound"
   retries: 30
   
 - debug:
@@ -30,16 +26,13 @@
   k8s_facts:
     api_version: v1
     kind: PersistentVolumeClaim
-    namespace: "{{ migration_sample_name }}"
+    namespace: "{{ namespace }}"
     label_selectors:
     - app=nginx
     field_selectors:
     - metadata.name=nginx-logs
-    - spec.storageClassName={{ logs_storageclass }}
-    - status.accessModes={{ logs_accessmode }}
-    - status.phase=Bound
   register: logs_pv
-  until: logs_pv.resources | length > 0
+  until: logs_pv.get("resources", []) and logs_pv.resources[0].get("status", {}).get("phase", "") == "Bound"
   retries: 30
 
 - debug:

--- a/roles/ocp-24706-volume/tasks/validate-source.yml
+++ b/roles/ocp-24706-volume/tasks/validate-source.yml
@@ -1,0 +1,99 @@
+- name: Check nodes status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app=nginx"
+  register: pod
+  until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
+  retries: 30
+
+- name: Check PV nginx-html status
+  k8s_facts:
+    api_version: v1
+    kind: PersistentVolumeClaim
+    namespace: "{{ migration_sample_name }}"
+    label_selectors:
+    - app=nginx
+    field_selectors:
+    - metadata.name=nginx-html
+    - spec.storageClassName={{ html_storageclass }}
+    - status.accessModes={{ html_accessmode }}
+    - status.phase=Bound 
+  register: html_pv 
+  until: html_pv.resources | length > 0
+  retries: 30
+  
+- debug:
+    msg: "{{ html_pv }}"
+
+- name: Check PV nginx-logs status
+  k8s_facts:
+    api_version: v1
+    kind: PersistentVolumeClaim
+    namespace: "{{ migration_sample_name }}"
+    label_selectors:
+    - app=nginx
+    field_selectors:
+    - metadata.name=nginx-logs
+    - spec.storageClassName={{ logs_storageclass }}
+    - status.accessModes={{ logs_accessmode }}
+    - status.phase=Bound
+  register: logs_pv
+  until: logs_pv.resources | length > 0
+  retries: 30
+
+- debug:
+    msg: "{{ logs_pv }}"
+    
+- name: Obtain route
+  k8s_facts:
+    kind: Route
+    namespace: "{{ namespace }}"
+    label_selectors: "app=nginx"
+  register: nginx_route
+
+- name: Acces the html file
+  uri:
+    url: http://{{ nginx_route.resources[0].spec.host }}
+    method: GET
+    status_code: 403 
+
+- name: To create the index.html file
+  shell:  "{{ oc_binary }} -n {{ namespace }} rsh $({{ oc_binary }} get pods -n {{ namespace }} -o jsonpath='{.items[0].metadata.name}') sh -c 'echo \"<h1>HELLO WORLD</h1>\" > /usr/share/nginx/html/index.html'"
+
+- name: Acces the html file again
+  uri:
+    url: http://{{ nginx_route.resources[0].spec.host }}
+    method: GET
+    status_code: 200 
+
+- name: Get /var/log/nginx/error.log file content
+  shell: "{{ oc_binary }} -n {{ namespace }} rsh $({{ oc_binary }} get pods -n {{ namespace }} -o jsonpath='{.items[0].metadata.name}') cat /var/log/nginx/error.log "
+  register: output
+  until: output.rc == 0 and output.stdout != ''
+  retries: 5
+
+- debug: msg={{ output.stdout_lines }}
+  name: /var/log/nginx/error.log file content
+
+- name: Fail if no forbidden error present in nginx access.log file. There must be 1 error
+  fail:
+     msg: There should be one and only one forbidden error in access.log file.
+  failed_when: 1 != ( output.stdout_lines | select('match', '.*directory index of "/usr/share/nginx/html/" is forbidden.*') | list | length )
+  
+
+- name: Get /var/log/nginx/access.log file content
+  shell: "{{ oc_binary }} -n {{ namespace }} rsh $({{ oc_binary }} get pods -n {{ namespace }} -o jsonpath='{.items[0].metadata.name}') cat /var/log/nginx/access.log "
+  register: output_access
+  until: output_access.rc == 0 and output_access.stdout != ''
+  retries: 5
+
+- debug: msg={{ output_access.stdout_lines }}
+  name: /var/log/nginx/access.log file content
+
+- name: Fail if no 200 code present in nginx access.log file. There must be 1 access
+  fail:
+     msg: There should be one and only one 200 code in access.log file.
+  failed_when: 1 != ( output_access.stdout_lines | select('match', '.*200 21 "-" \"ansible-httpget".*') | list | length )
+
+

--- a/roles/ocp-24706-volume/tasks/validate-target.yml
+++ b/roles/ocp-24706-volume/tasks/validate-target.yml
@@ -1,0 +1,90 @@
+- name: Check nodes status
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app=nginx"
+  register: pod
+  until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
+  retries: 30
+
+- name: Check PV nginx-html status
+  k8s_facts:
+    api_version: v1
+    kind: PersistentVolumeClaim
+    namespace: "{{ migration_sample_name }}"
+    label_selectors:
+    - app=nginx
+    field_selectors:
+    - metadata.name=nginx-html
+    - spec.storageClassName={{ dst_storage_class }}
+    - status.accessModes={{ html_accessmode }}
+    - status.phase=Bound 
+  register: html_pv 
+  until: html_pv.resources | length > 0
+  retries: 30
+  
+- debug:
+    msg: "{{ html_pv }}"
+
+- name: Check PV nginx-logs status
+  k8s_facts:
+    api_version: v1
+    kind: PersistentVolumeClaim
+    namespace: "{{ migration_sample_name }}"
+    label_selectors:
+    - app=nginx
+    field_selectors:
+    - metadata.name=nginx-logs
+    - spec.storageClassName={{ dst_storage_class }}
+    - status.accessModes={{ logs_accessmode }}
+    - status.phase=Bound
+  register: logs_pv
+  until: logs_pv.resources | length > 0
+  retries: 30
+
+- debug:
+    msg: "{{ logs_pv }}"
+    
+- name: Obtain route
+  k8s_facts:
+    kind: Route
+    namespace: "{{ namespace }}"
+    label_selectors: "app=nginx"
+  register: nginx_route
+
+- name: Acces the html file again
+  uri:
+    url: http://{{ nginx_route.resources[0].spec.host }}
+    method: GET
+    status_code: 200 
+
+- name: Get /var/log/nginx/error.log file content
+  shell: "{{ oc_binary }} -n {{ namespace }} rsh $({{ oc_binary }} get pods -n {{ namespace }} -o jsonpath='{.items[0].metadata.name}') cat /var/log/nginx/error.log "
+  register: output
+  until: output.rc == 0 and output.stdout != ''
+  retries: 5
+
+- debug: msg={{ output.stdout_lines }}
+  name: /var/log/nginx/error.log file content
+
+- name: Fail if no forbidden error present in nginx access.log file. There must be 1 error
+  fail:
+     msg: There should be one and only one forbidden error in access.log file.
+  failed_when: 1 != ( output.stdout_lines | select('match', '.*directory index of "/usr/share/nginx/html/" is forbidden.*') | list | length )
+  
+
+- name: Get /var/log/nginx/access.log file content
+  shell: "{{ oc_binary }} -n {{ namespace }} rsh $({{ oc_binary }} get pods -n {{ namespace }} -o jsonpath='{.items[0].metadata.name}') cat /var/log/nginx/access.log "
+  register: output_access
+  until: output_access.rc == 0 and output_access.stdout != ''
+  retries: 5
+
+- debug: msg={{ output_access.stdout_lines }}
+  name: /var/log/nginx/access.log file content
+
+- name: Fail if no 200 code present in nginx access.log file. There must be 1 access
+  fail:
+     msg: There should be one and only one 200 code in access.log file.
+  failed_when: 2 < ( output_access.stdout_lines | select('match', '.*200 21 "-" \"ansible-httpget".*') | list | length )
+
+

--- a/roles/ocp-24706-volume/tasks/validate-target.yml
+++ b/roles/ocp-24706-volume/tasks/validate-target.yml
@@ -11,16 +11,12 @@
   k8s_facts:
     api_version: v1
     kind: PersistentVolumeClaim
-    namespace: "{{ migration_sample_name }}"
-    label_selectors:
-    - app=nginx
+    namespace: "{{ namespace }}"
+    label_selectors: "app=nginx"
     field_selectors:
     - metadata.name=nginx-html
-    - spec.storageClassName={{ dst_storage_class }}
-    - status.accessModes={{ html_accessmode }}
-    - status.phase=Bound 
   register: html_pv 
-  until: html_pv.resources | length > 0
+  until: html_pv.get("resources", []) and html_pv.resources[0].get("status", {}).get("phase", "") == "Bound"
   retries: 30
   
 - debug:
@@ -30,16 +26,13 @@
   k8s_facts:
     api_version: v1
     kind: PersistentVolumeClaim
-    namespace: "{{ migration_sample_name }}"
+    namespace: "{{ namespace }}"
     label_selectors:
     - app=nginx
     field_selectors:
     - metadata.name=nginx-logs
-    - spec.storageClassName={{ dst_storage_class }}
-    - status.accessModes={{ logs_accessmode }}
-    - status.phase=Bound
   register: logs_pv
-  until: logs_pv.resources | length > 0
+  until: logs_pv.get("resources", []) and logs_pv.resources[0].get("status", {}).get("phase", "") == "Bound"
   retries: 30
 
 - debug:

--- a/roles/ocp-24706-volume/templates/nginx_with_pv_template.yml
+++ b/roles/ocp-24706-volume/templates/nginx_with_pv_template.yml
@@ -1,0 +1,154 @@
+# Copyright 2017 the Heptio Ark contributors.
+#
+# Popular example from velero tweaked to deploy in OpenShift
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  template: nginx-persistent-template
+message: |-
+  Creates a simple nginx app with two pv
+
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: ${NAMESPACE}
+    labels:
+      app: ${NAME}
+  
+- kind: PersistentVolumeClaim
+  apiVersion: v1
+  metadata:
+    name: ${NAME}-logs
+    namespace: ${NAMESPACE}
+    labels:
+      app: ${NAME}
+  spec:
+    accessModes:
+      - ${LOGS_ACCESSMODE}
+    storageClassName: ${LOGS_STORAGECLASS}
+    resources:
+      requests:
+        storage: 50Mi
+  
+- kind: PersistentVolumeClaim
+  apiVersion: v1
+  metadata:
+    name: ${NAME}-html
+    namespace: ${NAMESPACE}
+    labels:
+      app: ${NAME}
+  spec:
+    accessModes:
+      - ${HTML_ACCESSMODE}
+    storageClassName: ${HTML_STORAGECLASS}
+    resources:
+      requests:
+        storage: 50Mi
+  
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    name: ${NAME}-deployment
+    namespace: ${NAMESPACE}
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: ${NAME}
+      spec:
+        volumes:
+          - name: ${NAME}-logs
+            persistentVolumeClaim:
+             claimName: ${NAME}-logs
+          - name: ${NAME}-html
+            persistentVolumeClaim:
+             claimName: ${NAME}-html
+        containers:
+        - image: docker.io/twalter/openshift-nginx
+          name: ${NAME}
+          ports:
+          - containerPort: 8081
+          volumeMounts:
+            - mountPath: "/var/log/nginx"
+              name: ${NAME}-logs
+              readOnly: false
+            - mountPath: "/usr/share/nginx/html"
+              name: ${NAME}-html
+              readOnly: false
+  
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: ${NAME}
+    name: my-${NAME}
+    namespace: ${NAMESPACE}
+  spec:
+    ports:
+    - port: 8081
+      targetPort: 8081
+    selector:
+      app: ${NAME}
+    type: LoadBalancer
+  
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    name: my-${NAME}
+    namespace: ${NAMESPACE}
+    labels:
+      app: ${NAME}
+      service: my-${NAME}
+  spec:
+    to:
+      kind: Service
+      name: my-${NAME}
+    port:
+      targetPort: 8081
+  
+parameters:
+- description: Storage class to be used in the logs volume.
+  displayName: Logs Storage class
+  name: LOGS_STORAGECLASS
+  required: false
+  value: ""
+- description: Storage class to be used in the html volume.
+  displayName: Html Storage class
+  name: HTML_STORAGECLASS
+  required: false
+  value: ""
+- description: Access mode to be used in the html volume.
+  displayName: Html Access Mode
+  name: HTML_ACCESSMODE
+  required: true
+  value: "ReadWriteOnce"
+- description: Access mode to be used in the logs volume.
+  displayName: Logs access mode
+  name: LOGS_ACCESSMODE
+  required: true
+  value: "ReadWriteOnce"
+- description: Namespace used for the deployment.
+  displayName: Namespace
+  name: NAMESPACE
+  required: true
+  value: "nginx-example"
+- description: Name used for the application.
+  displayName: Name
+  name: NAME
+  required: true
+  value: "nginx"


### PR DESCRIPTION
This PR is used to automate  TC ocp-24706 Verify volume migration basic file usage	

The basic test flow are:
* Create in source OCP3 cluster a nginx application with two persistent volumes, one for html directory and another for logs directory, using the source storage class and access mode that need to be tested.
* Access the nginx, check that the route in the soure cluster is working fine
* Access the nginx logs
* do migration with specific `action` `copymethod` 
* check a nginx application works well in target cluster