### PR TITLE
Fix variable name

### DIFF
--- a/roles/ocp-24995-role/tasks/validate.yml
+++ b/roles/ocp-24995-role/tasks/validate.yml
@@ -4,8 +4,8 @@
     kind: Role
     namespace: "{{ namespace }}"
     name: "{{ rolename }}"
-  register: rolename
-  until: rolename.resources | length > 0
+  register: ret_role
+  until: ret_role.resources | length > 0
   retries: 30
 
 - name: Check RoleBinding


### PR DESCRIPTION
In roles testcase, the result of the Role query was being stored in an already existing variable.

This PR changes the name of the variable storing the result of this query.