### PR TITLE
Add ocp-31309-quotanoattach testcase

### DIFF
--- a/roles/ocp-31309-quotanoattach/defaults/main.yml
+++ b/roles/ocp-31309-quotanoattach/defaults/main.yml
@@ -1,0 +1,15 @@
+namespace: "ocp-31309-quotanoattach"
+
+storage_size: 1Mi
+access_mode: ReadWriteOnce
+
+migration_sample_name: "ocp-31309-quotanoattach"
+migration_plan_name: "{{ migration_sample_name }}-migplan-{{ ansible_date_time.epoch }}"
+migration_name: "{{ migration_sample_name }}-mig-{{ ansible_date_time.epoch }}"
+
+with_deploy: true
+with_migrate: true
+with_cleanup: true
+with_validate: true
+pv: false
+quiesce: false

--- a/roles/ocp-31309-quotanoattach/tasks/deploy.yml
+++ b/roles/ocp-31309-quotanoattach/tasks/deploy.yml
@@ -1,0 +1,58 @@
+- name: Check namespace
+  k8s_facts:
+    kind: Namespace
+    name: "{{ namespace }}"
+  register: ns
+
+- name: Create namespace
+  shell: "{{ oc_binary }} new-project {{ namespace }} --skip-config-write=true"
+  when: ns.resources | length == 0
+
+
+- name: Get LimitRange
+  k8s_info:
+    kind: LimitRange
+    namespace: "{{ namespace }}"
+  register: limitrange
+  until: limitrange.resources | length > 0
+  ignore_errors: true
+
+- name: Remove LimitRanges so that default limit ranges dont interfere with the test
+  k8s:
+    kind: LimitRange
+    state : absent
+    namespace: "{{ namespace }}"
+    name: "{{ item.metadata.name }}"
+  loop: "{{ limitrange.resources | default([]) }}"
+
+- name: Create resource quota
+  k8s:
+    state : present
+    definition: "{{ lookup('template', 'resourcequota.yml.j2' )}}"
+
+- name: Create persistent volume claim
+  k8s:
+    state : present
+    definition: "{{ lookup('template', 'persistent-volume-claim.yml.j2' )}}"
+
+- name: Provision the volume
+  k8s:
+    state : present
+    definition: "{{ lookup('template', 'provisioner-pod.yml.j2' )}}"
+
+
+- name: Wait until provision is done
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app=provision"
+    field_selectors: 
+    - status.phase=Succeeded
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- name: Remove the provisioner pod
+  k8s:
+    state : absent
+    definition: "{{ lookup('template', 'provisioner-pod.yml.j2' )}}"

--- a/roles/ocp-31309-quotanoattach/tasks/main.yml
+++ b/roles/ocp-31309-quotanoattach/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Cleanup resources
+  include_role:
+    name: migration_cleanup
+  when: with_cleanup|bool
+
+- name: Create resources
+  import_tasks: deploy.yml
+  when: with_deploy|bool
+
+- name: Start migration
+  import_tasks: migrate.yml
+  when: with_migrate|bool
+
+- name: Track migration
+  import_tasks: track.yml
+  when: with_migrate|bool
+
+- name: Validate migration
+  import_tasks: validate.yml
+  when: with_validate|bool

--- a/roles/ocp-31309-quotanoattach/tasks/migrate.yml
+++ b/roles/ocp-31309-quotanoattach/tasks/migrate.yml
@@ -1,0 +1,3 @@
+- name: Execute migration
+  include_role:
+    name: migration_run

--- a/roles/ocp-31309-quotanoattach/tasks/track.yml
+++ b/roles/ocp-31309-quotanoattach/tasks/track.yml
@@ -1,0 +1,3 @@
+- name: Track migration
+  include_role:
+    name: migration_track

--- a/roles/ocp-31309-quotanoattach/tasks/validate.yml
+++ b/roles/ocp-31309-quotanoattach/tasks/validate.yml
@@ -1,0 +1,38 @@
+- name: Get Quota
+  k8s_info:
+    kind: ResourceQuota
+    namespace: "{{ namespace }}"
+  register: quota
+  retries: 20
+  until: quota.resources | length > 0
+
+- name: Get Persistent Volume
+  k8s_info:
+    kind: PersistentVolumeClaim
+    namespace: "{{ namespace }}"
+    name: quoatdev-test
+  register: vol
+  retries: 10
+  until: vol.resources | length > 0
+
+- name: Validate the volume
+  k8s:
+    state : present
+    definition: "{{ lookup('template', 'validator-pod.yml.j2' )}}"
+
+
+- name: Wait until validation is done
+  k8s_facts:
+    kind: Pod
+    namespace: "{{ namespace }}"
+    label_selectors: "app=validation"
+    field_selectors: 
+    - status.phase=Succeeded
+  register: pod
+  until: pod.resources | length > 0
+  retries: 30
+
+- name: Validate the volume
+  k8s:
+    state : absent
+    definition: "{{ lookup('template', 'validator-pod.yml.j2' )}}"

--- a/roles/ocp-31309-quotanoattach/templates/persistent-volume-claim.yml.j2
+++ b/roles/ocp-31309-quotanoattach/templates/persistent-volume-claim.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: quoatdev-test
+  namespace: {{ namespace }}
+spec:
+  accessModes:
+    - {{ access_mode }}
+  resources:
+    requests:
+      storage: {{ storage_size }}

--- a/roles/ocp-31309-quotanoattach/templates/provisioner-pod.yml.j2
+++ b/roles/ocp-31309-quotanoattach/templates/provisioner-pod.yml.j2
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: provisioner-pod
+  namespace: {{ namespace }}
+  labels:
+    app: provision
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: provisioner
+    resources:
+      limits:
+        cpu: "0.01"
+        memory: 128Mi
+    image: alpine
+    command: [ "/bin/sh", "-c", "--" ]
+    args: [ "echo 'data inserted' > /data/vol/data.txt ; dd if=/dev/urandom of=/data/vol/binary.rnd  bs=1000000  count=1" ]
+    volumeMounts:
+    - name: testvolume
+      mountPath: /data/vol
+  volumes:
+  - name: testvolume
+    persistentVolumeClaim:
+      claimName: quoatdev-test

--- a/roles/ocp-31309-quotanoattach/templates/resourcequota.yml.j2
+++ b/roles/ocp-31309-quotanoattach/templates/resourcequota.yml.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: object-quota
+  namespace: {{ namespace }}
+spec:
+  hard:
+    persistentvolumeclaims: "2"
+    services.loadbalancers: "0"
+    services.nodeports: "0"
+    pods: "1"
+    replicationcontrollers: "1"
+    secrets: "6"
+    configmaps: "4"
+    services: "10"
+    limits.cpu: "20"
+    limits.memory: 20Gi
+    requests.cpu: "10"
+    requests.memory: 10Gi

--- a/roles/ocp-31309-quotanoattach/templates/validator-pod.yml.j2
+++ b/roles/ocp-31309-quotanoattach/templates/validator-pod.yml.j2
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: validator-pod
+  namespace: {{ namespace }}
+  labels:
+    app: validation
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: validator
+    image: alpine
+    resources:
+      limits:
+        cpu: "0.01"
+        memory: 128Mi
+    command: [ "/bin/sh", "-c", "--" ]
+    args:
+      - set -e;
+        echo 'Validating';
+        cd /data/vol;
+        ls data.txt;
+        ls binary.rnd;
+        export CONTENT=$(cat data.txt);
+        [[ "$CONTENT" == 'data inserted' ]] ||  { echo 'Wrong data content' && exit 1; } ;
+        export SIZE=$( wc -c binary.rnd  | cut -d ' ' -f 1 );
+        [[ $SIZE  == '1000000' ]] || { echo 'Wrong binary file size' && exit 1; };
+    volumeMounts:
+    - name: testvolume
+      mountPath: /data/vol
+  volumes:
+  - name: testvolume
+    persistentVolumeClaim:
+      claimName: quoatdev-test


### PR DESCRIPTION
Add testcase ocp-31309-quotanoattach:

1. Create a namespace
2. Create a resource quota
3. Create a PVC that is NOT attached to any pod
4. Provision some files in the PVC
5. Migrate the not attached PVC
6. Check that the provisioned files are ok


Not attached PVCs are only handled after 1.2.1 version. So in previous versions this TC will fail.